### PR TITLE
fix: update NDK to 28.2.13676358 and add ProGuard dontwarn for mlkit …

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
     }
     namespace = "io.caravella.egm"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = "27.0.12077973"
+    ndkVersion = "28.2.13676358"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -70,6 +70,7 @@ android {
     buildTypes {
         release {
             signingConfig = signingConfigs.getByName("release")
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,7 @@
+# google_mlkit_text_recognition optional language model classes.
+# These are only required when using Chinese/Devanagari/Japanese/Korean
+# recognition, which are not bundled in this app. Suppress R8 warnings.
+-dontwarn com.google.mlkit.vision.text.chinese.**
+-dontwarn com.google.mlkit.vision.text.devanagari.**
+-dontwarn com.google.mlkit.vision.text.japanese.**
+-dontwarn com.google.mlkit.vision.text.korean.**


### PR DESCRIPTION
…optional language packs

Agent-Logs-Url: https://github.com/calca/caravella/sessions/0f2ad8f4-27b1-47c9-bf30-d2df81351c46